### PR TITLE
Expose LogOutput class unconditionally

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -5,6 +5,8 @@ export 'src/ansi_color.dart';
 export 'src/filters/development_filter.dart';
 export 'src/filters/production_filter.dart';
 export 'src/log_filter.dart';
+// [LogOutput] class needs to be exposed unconditionally
+export 'src/log_output.dart';
 export 'src/log_output.dart'
     if (dart.library.io) 'src/outputs/file_output.dart';
 export 'src/log_printer.dart';


### PR DESCRIPTION
In the recent cleanup of logger.dart export file, the "duplicate" export of log_output was removed. However, on platforms supporting io we now can't define our own LogOutput classes. The unconditional export of log_output.dart should be added back.

Relevant change introducing this issue:
https://github.com/Bungeefan/logger/commit/bf2c13c30fdd9f8752748d938d23a6b81c5bcc31