### PR TITLE
fix Bad state: StreamSink is closed

### DIFF
--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -121,6 +121,8 @@ class AdvancedFileOutput extends LogOutput {
   Timer? _bufferFlushTimer;
   Timer? _targetFileUpdater;
 
+  bool isClosingSink;
+
   final List<OutputEvent> _buffer = [];
 
   bool get _rotatingFilesMode => _maxFileSizeKB > 0;
@@ -183,7 +185,7 @@ class AdvancedFileOutput extends LogOutput {
   }
 
   void _flushBuffer() {
-    if (_sink == null) return; // Wait until _sink becomes available
+    if (_sink == null || isClosingSink) return; // Wait until _sink becomes available
     for (final event in _buffer) {
       _sink?.writeAll(event.lines, Platform.isWindows ? '\r\n' : '\n');
       _sink?.writeln();
@@ -192,6 +194,7 @@ class AdvancedFileOutput extends LogOutput {
   }
 
   Future<void> _updateTargetFile() async {
+    if (isClosingSink) return; // if we are already closing, do nothing, because other functions will reopen the sink
     try {
       if (await _file.exists() &&
           await _file.length() > _maxFileSizeKB * 1024) {
@@ -205,8 +208,10 @@ class AdvancedFileOutput extends LogOutput {
       print(e);
       print(s);
       // Try creating another file and working with it
-      await _closeSink();
-      await _openSink();
+      if (!isClosingSink) {
+        await _closeSink();
+        await _openSink();
+      }
     }
   }
 
@@ -222,15 +227,23 @@ class AdvancedFileOutput extends LogOutput {
   }
 
   Future<void> _closeSink() async {
-    if (fileFooter != null) {
-      _sink?.writeln(fileFooter);
+    isClosingSink = true;
+    try {
+      if (fileFooter != null) {
+        _sink?.writeln(fileFooter);
+      }
+
+      final sink = _sink;
+      _sink = null; // disable writing in flushBuffer
+
+      await sink?.flush();
+      await sink?.close();
+    } catch (e, s) {
+      print('Failed to close sink: $e');
+      print(s);
+    } finally {
+      isClosingSink = false;
     }
-
-    final sink = _sink;
-    _sink = null; // disable writing in flushBuffer
-
-    await sink?.flush();
-    await sink?.close();
   }
 
   Future<void> _deleteRotatedFiles() async {


### PR DESCRIPTION
we have monitored in sentry that users are facing an occasional bug.
Bad state: StreamSink is closed


String: Bad state: StreamSink is closed
  #0      _StreamSinkImpl.add (dart:io/io_sink.dart:152)
  #1      _IOSinkImpl.write (dart:io/io_sink.dart:287)
  #2      _IOSinkImpl.writeAll (dart:io/io_sink.dart:298)
  #3      AdvancedFileOutput._flushBuffer (package:logger/src/outputs/advanced_file_output.dart:183)
  #4      AdvancedFileOutput.init.<fn> (package:logger/src/outputs/advanced_file_output.dart:161)
  #5      _Timer._runTimers (dart:isolate-patch/timer_impl.dart:398)
  #6      _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:429)
  #7      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:184)
  
  we found if sink is closed, we still have 3 or 4 lines of code to reopen it .
if timer starts task at the time , bug comes.