### PR TITLE
fix(AdvancedFileOutput): prevent StreamSink closed race during concurrent flush and file rotation (v3)fix Bad state: StreamSink is closed

### DIFF
--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -121,6 +121,8 @@ class AdvancedFileOutput extends LogOutput {
   Timer? _bufferFlushTimer;
   Timer? _targetFileUpdater;
 
+  bool isClosingSink;
+
   final List<OutputEvent> _buffer = [];
 
   bool get _rotatingFilesMode => _maxFileSizeKB > 0;
@@ -183,7 +185,7 @@ class AdvancedFileOutput extends LogOutput {
   }
 
   void _flushBuffer() {
-    if (_sink == null) return; // Wait until _sink becomes available
+    if (_sink == null || isClosingSink) return; // Wait until _sink becomes available
     for (final event in _buffer) {
       _sink?.writeAll(event.lines, Platform.isWindows ? '\r\n' : '\n');
       _sink?.writeln();
@@ -192,6 +194,7 @@ class AdvancedFileOutput extends LogOutput {
   }
 
   Future<void> _updateTargetFile() async {
+    if (isClosingSink) return; // if we are already closing, do nothing, because other functions will reopen the sink
     try {
       if (await _file.exists() &&
           await _file.length() > _maxFileSizeKB * 1024) {
@@ -205,8 +208,10 @@ class AdvancedFileOutput extends LogOutput {
       print(e);
       print(s);
       // Try creating another file and working with it
-      await _closeSink();
-      await _openSink();
+      if (!isClosingSink) {
+        await _closeSink();
+        await _openSink();
+      }
     }
   }
 
@@ -222,15 +227,23 @@ class AdvancedFileOutput extends LogOutput {
   }
 
   Future<void> _closeSink() async {
-    if (fileFooter != null) {
-      _sink?.writeln(fileFooter);
+    isClosingSink = true;
+    try {
+      if (fileFooter != null) {
+        _sink?.writeln(fileFooter);
+      }
+
+      final sink = _sink;
+      _sink = null; // disable writing in flushBuffer
+
+      await sink?.flush();
+      await sink?.close();
+    } catch (e, s) {
+      print('Failed to close sink: $e');
+      print(s);
+    } finally {
+      isClosingSink = false;
     }
-
-    final sink = _sink;
-    _sink = null; // disable writing in flushBuffer
-
-    await sink?.flush();
-    await sink?.close();
   }
 
   Future<void> _deleteRotatedFiles() async {


### PR DESCRIPTION
Summary

This PR re-introduces the fix for a rare concurrency issue in AdvancedFileOutput that can cause
Bad state: StreamSink is closed exceptions when a timer-triggered flush overlaps with a file rotation or sink closing.

Background

Sorry for closing the previous PR.
I initially submitted this fix against version 2.x, where we first observed the issue in production.
However, since all 2.x branches have now been removed, I re-tested on the latest 3.0.0 branch and confirmed
that the issue still occasionally occurs.
Therefore, I’m re-submitting this PR targeting v3.

Root Cause

When _flushBuffer() (triggered by the flush timer) and _updateTargetFile() (triggered by _targetFileUpdater
for rotation) execute concurrently, both may call _closeSink() or _openSink().
If the timer fires while the sink is being closed or reopened, the old _IOSink becomes invalid,
resulting in the runtime error:

```
Bad state: StreamSink is closed
#0 _StreamSinkImpl.add (dart:io/io_sink.dart:152)
#1 _IOSinkImpl.write (dart:io/io_sink.dart:287)
#2 _IOSinkImpl.writeAll (dart:io/io_sink.dart:298)
#3 AdvancedFileOutput._flushBuffer (package:logger/src/outputs/advanced_file_output.dart:183)
#4 AdvancedFileOutput.init.<anonymous closure> (package:logger/src/outputs/advanced_file_output.dart:161)
```

How to Reproduce

The issue is rare in normal configurations but can be consistently reproduced by:
	•	Setting maxDelay and fileUpdateDuration to very short intervals (tens or hundreds of milliseconds);
	•	Using a very small maxBufferSize and maxFileSizeKB to force frequent flushes and rotations;
	•	Continuously writing large log messages in a tight loop.

In this setup, when _targetFileUpdater triggers _updateTargetFile() and calls _closeSink()
while another _flushBuffer() is still running, the flush timer tries to write to a closed sink,
throwing the above exception.

Fix
	•	Add synchronization guards to ensure that _flushBuffer, _closeSink, and _updateTargetFile
do not run concurrently.
	•	Skip or delay flush attempts if _sink is already closing or reopening.

This ensures file rotation and flush operations are serialized and prevents writing to a closed sink.

Notes
	•	Originally observed in production (monitored via Sentry).
	•	Still reproducible in v3.0.0 under stress test conditions.
	•	This fix is fully backward-compatible and safe for existing users.